### PR TITLE
InsightFaceのモデルを追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+backend/buffalo_l.zip filter=lfs diff=lfs merge=lfs -text

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,1 +1,0 @@
-/buffalo_l.zip

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,7 +17,9 @@ COPY requirements1.txt ./
 RUN python3 -m pip install --requirement requirements1.txt
 COPY requirements2.txt ./
 RUN python3 -m pip install --requirement requirements2.txt
+
 # MEMO: http://storage.insightface.ai/ にアクセスできないため、一時的にダウンロード済みのモデルファイルを使用する。
+# RUN insightface-cli model.download buffalo_l
 COPY buffalo_l.zip /root/.insightface/models/buffalo_l.zip
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
@@ -25,7 +27,7 @@ RUN apt-get update \
   && rm --recursive --force /var/lib/apt/lists/* \
   && cd /root/.insightface/models/ \
   && unzip -d buffalo_l buffalo_l.zip
-RUN insightface-cli model.download buffalo_l
+
 COPY src/ ./src/
 RUN chmod 755 /root
 ENV HOME /root

--- a/backend/buffalo_l.zip
+++ b/backend/buffalo_l.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80ffe37d8a5940d59a7384c201a2a38d4741f2f3c51eef46ebb28218a7b0ca2f
+size 288621354


### PR DESCRIPTION
# 概要

InsightFaceのモデルが置かれているサイト（ http://storage.insightface.ai/ ）にアクセスできなくなっているため、ダウンロード済みのモデルファイルをリポジトリに追加しました。
Git LFSを使用しています。
